### PR TITLE
Add missed step to install dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,11 +35,15 @@ gem install jekyll bundler
 ```
 cd personal-website
 ```
-4. Build the site and make it available on a local server
+4. Install dependencies
+```
+bundle install
+```
+5. Build the site and make it available on a local server
 ```
 bundle exec jekyll serve
 ```
-5. Now browse to [http://localhost:4000](http://localhost:4000)
+6. Now browse to [http://localhost:4000](http://localhost:4000)
 
 ### Publish
 


### PR DESCRIPTION
This repository requires some additional instalation over of vanilla ruby. I
guess it is good idea to add into `README.md` command how to install it because
otherwise the user will stuck with error likes:
```
➜  personal-website git:(master) bundle exec jekyll serve
Could not find minitest-5.11.3 in any of the sources
Run `bundle install` to install missing gems.
➜  personal-website git:(master)
```