### PR TITLE
Simplify onboarding

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -1,0 +1,6 @@
+ports:
+- port: 4000
+  onOpen: open-preview
+tasks:
+- init: bundle install
+  command: bundle exec jekyll serve -H 0.0.0.0

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,6 @@
+FROM gitpod/workspace-full
+
+USER gitpod
+# add your tools here
+RUN /home/gitpod/.rvm/bin/rvm install "ruby-2.5.1" && \
+    /home/gitpod/.rvm/rubies/ruby-2.5.1/bin/gem install jekyll bundler

--- a/README.md
+++ b/README.md
@@ -41,6 +41,13 @@ bundle exec jekyll serve
 ```
 5. Now browse to [http://localhost:4000](http://localhost:4000)
 
+#### Code online
+
+You can alternatively develop your personal website in Gitpod, a free online dev environment for GitHub.
+It comes with all the needed configuration.
+
+[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/#https://github.com/github/personal-website)
+
 ### Publish
 
 When you host your personal website's code on GitHub, you get the support of free hosting through GitHub Pages.


### PR DESCRIPTION
Hello 👋,

this PR allows users to instantly start coding on their personal website without setting up a local dev environment. Gitpod is a free dev environment for GitHub that we have been working on. I think it is incredibly useful especially in a case like this where you only come back to once in a while for smaller changes.

Gitpod works btw. on any GitHub project without config (just prefix the GH URL with `gitpod.io/#`. But in this case I added config so that on start it runs:
 - `bundle install`
 - `bundle exec jekyll serve`

When the server is up, the website is shown in a preview on the right. Let me know what you think about it.



<img width="1586" alt="screenshot 2019-02-21 at 11 13 48" src="https://user-images.githubusercontent.com/372735/53161225-da610200-35c9-11e9-91ae-d00d75d573d4.png">
