### PR TITLE
fix posts may be not found problem

### DIFF
--- a/_includes/post-card.html
+++ b/_includes/post-card.html
@@ -1,7 +1,7 @@
 <div class="height-full text-left {% if site.style == 'dark' %}box-shadow{% else %}border border-gray-light{% endif %} bg-white rounded-1 p-3">
   <div class="d-flex flex-justify-between flex-items-start mb-1">
     <h1 class="f4 lh-condensed mb-1">
-      <a href="{{ post.url }}">
+      <a href=".{{ post.url }}">
         {{ post.title }}
       </a>
     </h1>


### PR DESCRIPTION
if the site is hosted with `https://name.github.io/repository-name/`, posts will be not found. Because at that time, a post url should be `https://name.github.io/repository-name/year/month/date/title/` but actually will be `https://name.github.io/year/month/date/title/`.