### PR TITLE
Update README.md to include bundle install instruction

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,11 +35,15 @@ gem install jekyll bundler
 ```
 cd personal-website
 ```
-4. Build the site and make it available on a local server
+4. Build the site
+```
+bundle install
+```
+5. Build the site and make it available on a local server
 ```
 bundle exec jekyll serve
 ```
-5. Now browse to [http://localhost:4000](http://localhost:4000)
+6. Now browse to [http://localhost:4000](http://localhost:4000)
 
 ### Publish
 


### PR DESCRIPTION
On my machine, following these directions I get:

>   Could not find thread_safe-0.3.6 in any of the sources
>   Run `bundle install` to install missing gems.

So I've changed the install instructions to include `bundle install`