### PR TITLE
remove duplicated repository owner name all over the site

### DIFF
--- a/_includes/repo-card.html
+++ b/_includes/repo-card.html
@@ -3,7 +3,6 @@
     <h1 class="f4 lh-condensed mb-1">
       <a href="{{ repository.html_url }}">
         {% octicon repo height:20 class:"mr-1 v-align-middle" fill:"#586069" aria-label:repo %}
-        <span class="text-normal">{{ repository.owner.login }} /</span>
         {{ repository.name }}
       </a>
     </h1>


### PR DESCRIPTION
Fix for https://github.com/github/personal-website/issues/27
* showing the repo owner name repeatedly in each project card is not adding any value for the site.
* cleaner look for project card.

**before**: 

<img width="1428" alt="screen shot 2019-02-24 at 12 37 57 pm" src="https://user-images.githubusercontent.com/8851163/53305031-134ee000-3831-11e9-9994-29171789a07c.png">


**after:**

<img width="1428" alt="screen shot 2019-02-24 at 12 37 08 pm" src="https://user-images.githubusercontent.com/8851163/53305033-1944c100-3831-11e9-8795-345d00077622.png">

