### PR TITLE
Adds Meta Description Tag

### DIFF
--- a/_includes/header.html
+++ b/_includes/header.html
@@ -10,10 +10,17 @@
 
 {% assign user = site.github.owner %}
 
+{% if page.path contains '_posts' %}
+  {% assign meta_description = page.content | strip_html | strip_newlines | truncate: 300 %}
+{% else %}
+  {% assign meta_description = user.bio | strip_html | strip_newlines | truncate: 300 %}
+{% endif %}
+
 <!doctype html>
 <html>
   <head>
     <meta charset="utf-8">
+    <meta name="description" content="{{ meta_description }}" />
     <title>{{ user.name }}</title>
     <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
     <link href="{{ "/assets/styles.css" | absolute_url }}" rel="stylesheet" type="text/css">

--- a/_includes/header.html
+++ b/_includes/header.html
@@ -11,9 +11,9 @@
 {% assign user = site.github.owner %}
 
 {% if page.path contains '_posts' %}
-  {% assign meta_description = page.content | strip_html | strip_newlines | truncate: 300 %}
+  {% assign meta_description = page.content | strip_html | strip_newlines | xml_escape | truncate: 300 %}
 {% else %}
-  {% assign meta_description = user.bio | strip_html | strip_newlines | truncate: 300 %}
+  {% assign meta_description = user.bio | strip_html | strip_newlines | xml_escape | truncate: 300 %}
 {% endif %}
 
 <!doctype html>


### PR DESCRIPTION
This branch adds the `<meta name="description" content="..." />` tag to the page header. Jekyll will strip new lines, html, and truncate it to `300` characters (which after reading a few [blog posts](https://moz.com/blog/how-long-should-your-meta-description-be-2018) seems to be considered optimal). The description tag is one of the meta tags which [Google recommends](https://support.google.com/webmasters/answer/79812?hl=en) including in your page head.

The homepage will display the users Github bio as the description.

<img width="968" alt="screen shot 2019-02-24 at 7 02 18 pm" src="https://user-images.githubusercontent.com/10888441/53307500-36948200-3867-11e9-817e-b2fcfdbe2869.png">

Where as the post page will include the first 300 characters from the actual post.

<img width="968" alt="screen shot 2019-02-24 at 7 02 32 pm" src="https://user-images.githubusercontent.com/10888441/53307506-4318da80-3867-11e9-9d9d-7ed0fe9381bb.png">

