### PR TITLE
Support baseurl in URLs for posts

### DIFF
--- a/_includes/post-card.html
+++ b/_includes/post-card.html
@@ -1,7 +1,7 @@
 <div class="height-full text-left {% if site.style == 'dark' %}box-shadow{% else %}border border-gray-light{% endif %} bg-white rounded-1 p-3">
   <div class="d-flex flex-justify-between flex-items-start mb-1">
     <h1 class="f4 lh-condensed mb-1">
-      <a href="{{ post.url }}">
+      <a href="{{ site.baseurl }}{{ post.url }}">
         {{ post.title }}
       </a>
     </h1>

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -20,7 +20,7 @@
       <div class="mx-auto" style="max-width: 900px;">
         <div class="f4 {% if site.style == 'dark' %}text-white{% endif %} mb-6">
           <div class="f4 {% if site.style == 'dark' %}text-white{% endif %}">
-            <p class="f5"><a href="/" class="d-flex flex-items-center {% if site.style == 'dark' %}text-white{% endif %}">{% octicon chevron-left height:16 class:"mr-2 v-align-middle" fill:{{ icon_color }} aria-label:Home %}Home</a></p>
+            <p class="f5"><a href="{{ site.url }}{{ site.baseurl | append:'/' }}" class="d-flex flex-items-center {% if site.style == 'dark' %}text-white{% endif %}">{% octicon chevron-left height:16 class:"mr-2 v-align-middle" fill:{{ icon_color }} aria-label:Home %}Home</a></p>
             <h1 class="f00-light lh-condensed mb-5">{{ page.title }}</h1>
             {{ content }}
           </div>

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -21,7 +21,7 @@
       <div class="mx-auto" style="max-width: 900px;">
         <div class="f4 {% if site.style == 'dark' %}text-white{% endif %} mb-6">
           <div class="f4 {% if site.style == 'dark' %}text-white{% endif %}">
-            <p class="f5"><a href="/" class="d-flex flex-items-center {% if site.style == 'dark' %}text-white{% endif %}">{% octicon chevron-left height:16 class:"mr-2 v-align-middle" fill:{{ icon_color }} aria-label:Home %}Home</a></p>
+            <p class="f5"><a href="{{ site.url }}{{ site.baseurl | append:'/' }}" class="d-flex flex-items-center {% if site.style == 'dark' %}text-white{% endif %}">{% octicon chevron-left height:16 class:"mr-2 v-align-middle" fill:{{ icon_color }} aria-label:Home %}Home</a></p>
             <h1 class="f00-light lh-condensed">{{ page.title }}</h1>
             <p class="{% if site.style == 'dark' %}text-white{% else %}text-gray{% endif %} mb-5">Published {{ page.date | date: "%b %d, %Y"}}</p>
             {{ content }}


### PR DESCRIPTION
This PR adds support for the `baseurl` parameter, ensuring links to posts (and links back "home") include the `baseurl`, if defined.

cc/ @pizzafox

Closes #50 