### PR TITLE
Switch Font to a Better Presentation

### DIFF
--- a/assets/styles.scss
+++ b/assets/styles.scss
@@ -1,11 +1,11 @@
 ---
 ---
 @import url('https://unpkg.com/primer/build/build.css');
-@import url('https://fonts.googleapis.com/css?family=Rubik:400,500,700,900');
+@import url('https://fonts.googleapis.com/css?family=Titillium+Web');
 @import 'highlight-syntax';
 
 body {
-  font-family: 'Rubik', sans-serif;
+  font-family: 'Titillium Web', sans-serif;
 }
 
 .github-component {


### PR DESCRIPTION
I switched the `Rubik` font to [Titillium Web](https://fonts.google.com/specimen/Titillium+Web).

Personally, I think it definitely looks better. A screenshot is provided below. I didn't think those font weights included in the Google Fonts url are needed, so I removed them.

![image](https://user-images.githubusercontent.com/30528433/53879061-6bda6600-4005-11e9-9043-fea809bc937b.png)

Hope this can be merged :) There should be no problem with merging as this is just a slight change on the font.
Thanks for developing this project. It is really great.
