### PR TITLE
Remove Rubik as default font

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,13 +147,16 @@ Jekyll's convention for defining layouts is very flexible. You can [learn more a
 
 ## Styles
 
-Your website is pre-configured to use [GitHub's very flexible CSS framework called "Primer,"](https://styleguide.github.com/primer/) alongside any custom styles you write in your `/assets/styles.scss` Sass stylesheet. It's currently referenced within your `styles.scss` file, using the CSS import at-rule:
+Your website is pre-configured to use [GitHub's very flexible CSS framework called "Primer,"](https://styleguide.github.com/primer/). It's currently referenced within your `styles.scss` file, using the CSS import at-rule:
 
 ```
 @import url('https://unpkg.com/primer/build/build.css');
 ```
 
 You are, of course, welcome to remove it or replace it with another framework. Just bear in mind that the HTML that your website came pre-packaged with references multiple Primer "utility classes" to define things like column widths, margins, and background colors.
+
+You also have the option to add on to and extend Primer's styles by adding custom CSS to your `/assets/styles.scss` Sass stylesheet. By editing this file, you can customize your website's color scheme, typography, and more.
+
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -147,7 +147,7 @@ Jekyll's convention for defining layouts is very flexible. You can [learn more a
 
 ## Styles
 
-Your website is pre-configured to use [a very flexible CSS framework called "Primer,"](https://styleguide.github.com/primer/) alongside any custom styles you write in your `/assets/styles.scss` Sass stylesheet. It's currently referenced within your `styles.scss` file, using the CSS import at-rule:
+Your website is pre-configured to use [GitHub's very flexible CSS framework called "Primer,"](https://styleguide.github.com/primer/) alongside any custom styles you write in your `/assets/styles.scss` Sass stylesheet. It's currently referenced within your `styles.scss` file, using the CSS import at-rule:
 
 ```
 @import url('https://unpkg.com/primer/build/build.css');

--- a/assets/styles.scss
+++ b/assets/styles.scss
@@ -1,15 +1,12 @@
 ---
 ---
 @import url('https://unpkg.com/primer/build/build.css');
-@import url('https://fonts.googleapis.com/css?family=Rubik:400,500,700,900');
 @import 'highlight-syntax';
 
-body {
-  font-family: 'Rubik', sans-serif;
-}
 
+// If a user adds a custom font, this component will stop it from bleeding into GitHub components:
 .github-component {
-  font-family: -apple-system,BlinkMacSystemFont,Segoe UI,Helvetica,Arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol;
+  font-family: -apple-system,BlinkMacSystemFont,Segoe UI,Helvetica,Arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol !important;
 }
 
 .repo-language-color {


### PR DESCRIPTION
Rubik wasn't adding much, and I'd like us to encourage users to include their own fonts. Using system fonts as the base will also bring the page weight down a bit. So in this PR I'm removing Rubik and updating the docs to add more clarity to where users can add custom styles. 

(Thanks to @hifocus for the inspiration to do this! https://github.com/github/personal-website/pull/66)

cc @brandonrosage 