### PR TITLE
fix mixed content

### DIFF
--- a/_includes/header.html
+++ b/_includes/header.html
@@ -23,6 +23,6 @@
     <meta name="description" content="{{ meta_description }}" />
     <title>{{ user.name }}</title>
     <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
-    <link href="{{ "/assets/styles.css" | absolute_url }}" rel="stylesheet" type="text/css">
+    <link href="{{ "/assets/styles.css" | relative_url }}" rel="stylesheet" type="text/css">
   </head>
   <body class="bg-white height-full" {% if site.style == 'dark' %}style="background-color: #2f363d !important"{% endif %}>


### PR DESCRIPTION
absolute_url will use `http` ([issue](https://github.com/jekyll/jekyll/issues/5590)) which will throw a mixed content error on `https` pages