### PR TITLE
Synchronize _data/colors.json with lib/linguist/languages.yml

### DIFF
--- a/_data/colors.json
+++ b/_data/colors.json
@@ -308,7 +308,7 @@
         "url": "https://github.com/trending?l=DM"
     },
     "Dockerfile": {
-        "color": "#0db7ed",
+        "color": "#384d54",
         "url": "https://github.com/trending?l=Dockerfile"
     },
     "Dogescript": {
@@ -416,7 +416,7 @@
         "url": "https://github.com/trending?l=Frege"
     },
     "Game Maker Language": {
-        "color": "#8fb200",
+        "color": "#71b417",
         "url": "https://github.com/trending?l=Game-Maker-Language"
     },
     "GAMS": {
@@ -436,7 +436,7 @@
         "url": "https://github.com/trending?l=GDB"
     },
     "GDScript": {
-        "color": null,
+        "color": "#355570",
         "url": "https://github.com/trending?l=GDScript"
     },
     "Genie": {
@@ -464,7 +464,7 @@
         "url": "https://github.com/trending?l=GLSL"
     },
     "Glyph": {
-        "color": "#e4cc98",
+        "color": "#c1ac7f",
         "url": "https://github.com/trending?l=Glyph"
     },
     "Gnuplot": {
@@ -472,7 +472,7 @@
         "url": "https://github.com/trending?l=Gnuplot"
     },
     "Go": {
-        "color": "#375eab",
+        "color": "#00ADD8",
         "url": "https://github.com/trending?l=Go"
     },
     "Golo": {
@@ -632,7 +632,7 @@
         "url": "https://github.com/trending?l=Kotlin"
     },
     "KRL": {
-        "color": "#28431f",
+        "color": "#28430A",
         "url": "https://github.com/trending?l=KRL"
     },
     "LabVIEW": {
@@ -1080,7 +1080,7 @@
         "url": "https://github.com/trending?l=R"
     },
     "Racket": {
-        "color": "#22228f",
+        "color": "#3c5caa",
         "url": "https://github.com/trending?l=Racket"
     },
     "Ragel": {
@@ -1128,7 +1128,7 @@
         "url": "https://github.com/trending?l=REXX"
     },
     "Ring": {
-        "color": "#0e60e3",
+        "color": "#2D54CB",
         "url": "https://github.com/trending?l=Ring"
     },
     "RobotFramework": {
@@ -1340,7 +1340,7 @@
         "url": "https://github.com/trending?l=Vala"
     },
     "VCL": {
-        "color": "#0298c3",
+        "color": "#148AA8",
         "url": "https://github.com/trending?l=VCL"
     },
     "Verilog": {


### PR DESCRIPTION
## Changed
* Synchronize `_data/colors.json`  with `lib/linguist/languages.yml` in [github/linguist](https://github.com/github/linguist)

Please see [the file change](https://github.com/github/personal-website/pull/95/files).
The purpose of this PR is to make consistent GitHub color used in personal-website.

## Method of change
This change has **done automatically** to avoid human error. Here is a script to make this change.

ruby script: <https://github.com/nwtgck/public-code/blob/master/github-personl-web-colors-json-sync/main.rb>

### Run information

Here is information to run the script above.

```bash
$ cd public-code/github-personl-web-colors-json-sync
$ ruby main.rb
[INFO] Language Dockerfile's color changed: #0db7ed => #384d54'
[INFO] Language Game Maker Language's color changed: #8fb200 => #71b417'
[INFO] Language GDScript's color changed:  => #355570'
[INFO] Language Glyph's color changed: #e4cc98 => #c1ac7f'
[INFO] Language Go's color changed: #375eab => #00ADD8'
[INFO] Language KRL's color changed: #28431f => #28430A'
[WARN] languages_hash[language] is nill where language == Matlab
[WARN] languages_hash[language] is nill where language == PAWN
[INFO] Language Racket's color changed: #22228f => #3c5caa'
[INFO] Language Ring's color changed: #0e60e3 => #2D54CB'
[INFO] Language VCL's color changed: #0298c3 => #148AA8'
colors.json generated!
```