### PR TITLE
Fixed issue with markdown pages

### DIFF
--- a/_includes/header.html
+++ b/_includes/header.html
@@ -4,8 +4,6 @@
   {% assign icon_color = "#24292e" %}
 {% endif %}
 
-{% assign content = page.content %}
-
 {% assign posts_total = site.posts | size %}
 
 {% assign user = site.github.owner %}


### PR DESCRIPTION
This change allows Jekyll to convert pages written with markdown to HTML. 

Jekyll stores the rendered HTML in `content` and the raw markdown in `page.content`. This change should not have an effect on pages that are just written in HTML. But it will cause pages written in markdown to be displayed correctly. 

To test this change, create a markdown page that includes markdown syntax. If you build the Jekyll site, the markdown content should be displayed as rendered HTML. If you add back in the line `{% assign content = page.content %}`, the page will just show the markdown content as plain text.