### PR TITLE
Fix text color of highlighter for dark style

### DIFF
--- a/_sass/_highlight-syntax.scss
+++ b/_sass/_highlight-syntax.scss
@@ -1,4 +1,4 @@
-.highlight  { width: 100%; overflow: auto; background: #ffffff; }
+.highlight  { width: 100%; overflow: auto; background: #ffffff; color: #24292e }
 .highlight .c { color: #999988; font-style: italic } /* Comment */
 .highlight .err { color: #a61717; background-color: #e3d2d2 } /* Error */
 .highlight .k { font-weight: bold } /* Keyword */


### PR DESCRIPTION
fix #201

Fixed that the character can not be seen if the style is set to dark