### PR TITLE
Added comment support for blog posts using Disqus and commentbox.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -184,6 +184,36 @@ While you can define a `layout` in the front matter, your website is pre-configu
 
 Jekyll's conventions for authoring and managing blog posts is very flexible. You can [learn more in Jekyll's documentation for "Posts."](https://jekyllrb.com/docs/posts/)
 
+#### Post Comments
+
+To enable comments on your posts edit `_config.yml` and un-comment the `post_comments` section. 
+
+**Note:** By default, [Disqus](https://disqus.com/) and [CommentBox](https://commentbox.io) are supported from within the `post` layout.
+
+```yaml
+post_comments:
+  service: commentbox.io
+```
+
+Then, open `_data/comments.yml` and enter your identifier for your service. 
+
+* For **commentbox.io**, this is the indentifier provided after you create a new site. _ie: `1234567890123456-proj`_
+* For **disqus**, this is the custom domain they provide you. _ie: `my-domain-net.disqus.com`._
+
+```yaml
+commentbox.io:
+  identifier: XXXXXXXXXXXXXXXX-proj
+```
+
+In order to actually get the comments to display on a post, you need to add the `comments` entry to your posts [front matter](https://jekyllrb.com/docs/front-matter/).
+
+```
+---
+title: "My Blog Post"
+comments: true
+---
+```
+
 ## Content and templates
 
 To give you a sound foundation to start your personal website, your repository includes a handful of "includes" -- dynamic `.html` files that are re-used throughout your website. They're all stored in the `/_includes/` directory.

--- a/_config.yml
+++ b/_config.yml
@@ -46,6 +46,9 @@ projects:
   # website: http://your_website_url
   # youtube: your_username
 
+# post_comments:
+  # service: commentbox.io
+
 topics:
   - name: CSS
     web_url: https://github.com/topics/css

--- a/_data/comments.yml
+++ b/_data/comments.yml
@@ -1,0 +1,6 @@
+disqus:
+  identifier: my-identifier-net.disqus.com
+
+commentbox.io:
+  identifier: XXXXXXXXXXXXXXXX-proj
+  

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -44,6 +44,34 @@
       <h1 class="f00-light lh-condensed">{{ page.title }}</h1>
       <p class="{% if site.style == 'dark' %}text-white{% else %}text-gray{% endif %} mb-5">Published {{ page.date | date: "%b %d, %Y"}}</p>
       {{ post_body }}
+      {% if site.post_comments %}
+          {% if page.comments %}
+              {% assign comments_service = site.data.comments[site.post_comments.service] %}
+              
+              {% if site.post_comments.service == "commentbox.io" %}
+                  <div class="commentbox"></div>
+                  <script src="https://unpkg.com/commentbox.io/dist/commentBox.min.js"></script>
+                  <script>
+                      commentBox('{{ comments_service.identifier }}');
+                  </script>
+              {% elsif site.post_comments.service == "disqus" %}
+                  <div id="disqus_thread"></div>
+                  <script>
+                      var disqus_config = function() {
+                          this.page.url = "{{ page.url | prepend: site.url | prepend: site.baseurl }}";
+                          this.page.identifier = "{{ page.url | prepend: site.url | prepend: site.baseurl }}";
+                      };
+                      (function() {
+                          var d = document, s = d.createElement('script');
+                          s.src = 'https://{{ comments_service.identifier }}/embed.js';
+                          s.setAttribute('data-timestamp', +new Date());
+                          (d.head || d.body).appendChild(s);
+                      })();
+                  </script>
+                  <noscript>Please enable JavaScript to view the <a href="https://disqus.com/?ref_noscript">comments powered by Disqus.</a></noscript>
+              {% endif %}
+          {% endif %}
+      {% endif %}
     </div>
   </div>
 {% else %}
@@ -60,6 +88,34 @@
             <h1 class="f00-light lh-condensed">{{ page.title }}</h1>
             <p class="{% if site.style == 'dark' %}text-white{% else %}text-gray{% endif %} mb-5">Published {{ page.date | date: "%b %d, %Y"}}</p>
             {{ post_body }}
+            {% if site.post_comments %}
+                {% if page.comments %}
+                    {% assign comments_service = site.data.comments[site.post_comments.service] %}
+                    
+                    {% if site.post_comments.service == "commentbox.io" %}
+                        <div class="commentbox"></div>
+                        <script src="https://unpkg.com/commentbox.io/dist/commentBox.min.js"></script>
+                        <script>
+                            commentBox('{{ comments_service.identifier }}');
+                        </script>
+                    {% elsif site.post_comments.service == "disqus" %}
+                        <div id="disqus_thread"></div>
+                        <script>
+                            var disqus_config = function() {
+                                this.page.url = "{{ page.url | prepend: site.url | prepend: site.baseurl }}";
+                                this.page.identifier = "{{ page.url | prepend: site.url | prepend: site.baseurl }}";
+                            };
+                            (function() {
+                                var d = document, s = d.createElement('script');
+                                s.src = 'https://{{ comments_service.identifier }}/embed.js';
+                                s.setAttribute('data-timestamp', +new Date());
+                                (d.head || d.body).appendChild(s);
+                            })();
+                        </script>
+                        <noscript>Please enable JavaScript to view the <a href="https://disqus.com/?ref_noscript">comments powered by Disqus.</a></noscript>
+                    {% endif %}
+                {% endif %}
+            {% endif %}
           </div>
         </div>
       </div>

--- a/_posts/2019-01-29-hello-world.md
+++ b/_posts/2019-01-29-hello-world.md
@@ -1,6 +1,7 @@
 ---
 title: "Welcome to Jekyll!"
 published: false
+comments: false
 ---
 
 **Hello world**, this is my first Jekyll blog post.


### PR DESCRIPTION
Added support to display comments on blog posts using configured services. 

The package now comes pre-loaded with support for disqus and commentbox.io

See updated `README.md` under `Adding blog posts -> Post Comments`