### PR TITLE
Hide star and fork icons when they are zero

### DIFF
--- a/_includes/repo-card.html
+++ b/_includes/repo-card.html
@@ -15,12 +15,12 @@
         <span class="repo-language-color ml-0 mr-1" style="background-color:{{ site.data.colors[repository.language]["color"] }}"></span>
         <span class="mr-3" itemprop="programmingLanguage">{{ repository.language }}</span>
     {% endif %}
-    {% if repository.stargazers_count %}
+    {% if repository.stargazers_count and repository.stargazers_count != 0 %}
       <a href="{{ repository.html_url }}/stargazers" class="d-inline-block link-gray mr-4">
         <svg class="octicon octicon-star mr-1" viewBox="0 0 14 16" version="1.1" width="14" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M14 6l-4.9-.64L7 1 4.9 5.36 0 6l3.6 3.26L2.67 14 7 11.67 11.33 14l-.93-4.74L14 6z"></path></svg>{{ repository.stargazers_count }}
       </a>
     {% endif %}
-    {% if repository.forks_count %}
+    {% if repository.forks_count and repository.forks_count != 0 %}
       <a href="{{ repository.html_url }}/network/members" class="d-inline-block link-gray mr-4">
         <svg class="octicon octicon-git-branch mr-1" viewBox="0 0 10 16" version="1.1" width="10" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M10 5c0-1.11-.89-2-2-2a1.993 1.993 0 0 0-1 3.72v.3c-.02.52-.23.98-.63 1.38-.4.4-.86.61-1.38.63-.83.02-1.48.16-2 .45V4.72a1.993 1.993 0 0 0-1-3.72C.88 1 0 1.89 0 3a2 2 0 0 0 1 1.72v6.56c-.59.35-1 .99-1 1.72 0 1.11.89 2 2 2 1.11 0 2-.89 2-2 0-.53-.2-1-.53-1.36.09-.06.48-.41.59-.47.25-.11.56-.17.94-.17 1.05-.05 1.95-.45 2.75-1.25S8.95 7.77 9 6.73h-.02C9.59 6.37 10 5.73 10 5zM2 1.8c.66 0 1.2.55 1.2 1.2 0 .65-.55 1.2-1.2 1.2C1.35 4.2.8 3.65.8 3c0-.65.55-1.2 1.2-1.2zm0 12.41c-.66 0-1.2-.55-1.2-1.2 0-.65.55-1.2 1.2-1.2.65 0 1.2.55 1.2 1.2 0 .65-.55 1.2-1.2 1.2zm6-8c-.66 0-1.2-.55-1.2-1.2 0-.65.55-1.2 1.2-1.2.65 0 1.2.55 1.2 1.2 0 .65-.55 1.2-1.2 1.2z"></path></svg>{{ repository.forks_count }}
       </a>


### PR DESCRIPTION
Hi, developers. Thank you very much for your wonderful project!

## Changed
* Hide star and fork icons and numbers when they are zero

That representation is the same as GitHub official does.

## Preview
Here is a preview. The following repo has no star and no fork, so not displayed the icons and 0.
![image](https://user-images.githubusercontent.com/10933561/62419373-6880fe80-b6b9-11e9-8594-ec597c1d5706.png)
