### PR TITLE
Fix hard coded href of the stacked default layout's Home link

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -5,7 +5,7 @@
     {% include masthead.html metadata=false %}
 
     <div class="container-md f4 text-left border rounded-2 bg-white p-3 p-sm-5 mt-6">
-      <p class="f5"><a href="/" class="d-flex flex-items-center">{% octicon chevron-left height:16 class:"mr-2 v-align-middle" fill:#0366d6 aria-label:Home %}Home</a></p>
+      <p class="f5"><a href="{{ site.url }}{{ site.baseurl | append:'/' }}" class="d-flex flex-items-center">{% octicon chevron-left height:16 class:"mr-2 v-align-middle" fill:#0366d6 aria-label:Home %}Home</a></p>
       <h1 class="f00-light lh-condensed mb-5">{{ page.title }}</h1>
       {{ content }}
     </div>


### PR DESCRIPTION
Fix hard coded href of the default layout's Home link when stacked.


If site's layout is  `sidebar`, the href of the Home link is `{{ site.url }}{{ site.baseurl | append:'/' }}` but still `/` when `stacked`. So, I changed them to be same.
It is crucial when a blog's url has one or more depth like https://ghkim3221.github.io/portfolio.

Thank you.