### PR TITLE
fix hover effect on repo name inside repo card

### DIFF
--- a/_includes/repo-card.html
+++ b/_includes/repo-card.html
@@ -2,9 +2,9 @@
   <div>
     <div class="d-flex flex-justify-between flex-items-start mb-1">
       <h1 class="f4 lh-condensed mb-1">
-        <a href="{{ repository.html_url }}">
+        <a href="{{ repository.html_url }}" class="span-underline">
           {% octicon repo height:20 class:"mr-1 v-align-middle" fill:"#586069" aria-label:repo %}
-          {{ repository.name }}
+          <span>{{ repository.name }}</span>
         </a>
       </h1>
     </div>

--- a/assets/styles.scss
+++ b/assets/styles.scss
@@ -52,3 +52,11 @@
 .min-height-full {
   min-height: 100vh;
 }
+
+a.span-underline:hover {
+  text-decoration: none;
+}
+
+a.span-underline>span:hover {
+  text-decoration: underline;
+}


### PR DESCRIPTION
I took the route of using CSS.

However the other option is to change the svg and repo name to oneliner

Other option
```html
<a href="{{ repository.html_url }}">
  {% octicon repo height:20 class:"mr-1 v-align-middle" fill:"#586069" aria-label:repo %}{{ repository.name }}
</a>
```

before
![image](https://user-images.githubusercontent.com/1661688/66275116-bf57af80-e885-11e9-843a-d67f6832a301.png)

after
![image](https://user-images.githubusercontent.com/1661688/66275103-9df6c380-e885-11e9-842d-2120c4b8ca55.png)
