### PR TITLE
Update "Primer styles" link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -210,7 +210,7 @@ Jekyll's convention for defining layouts is very flexible. You can [learn more a
 
 ## Styles
 
-Your website is pre-configured to use [GitHub's very flexible CSS framework called "Primer,"](https://styleguide.github.com/primer/). It's currently referenced within your `styles.scss` file, using the CSS import at-rule:
+Your website is pre-configured to use [GitHub's very flexible CSS framework called "Primer,"](https://primer.style/css/). It's currently referenced within your `styles.scss` file, using the CSS import at-rule:
 
 ```
 @import url('https://unpkg.com/primer/build/build.css');


### PR DESCRIPTION
When clicking on `GitHub's very flexible CSS framework called "Primer,"` link, it shows `This style guide will be deprecated soon! Please visit primer.style/css for the most up-to-date documentation.` at the top.

This commit changes this link to `https://primer.style/css/` for the most up-to-date documentation.