### PR TITLE
Fix: Error Faraday::Error::ClientError while attempting to serve #166

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,3 +3,4 @@ gem 'github-pages', group: :jekyll_plugins
 gem "jekyll-github-metadata"
 gem "jekyll-octicons"
 gem "jemoji"
+gem 'faraday', '~> 0.17.3'


### PR DESCRIPTION
The Faraday version was unstable as it was giving build errors to lots of people. The previous stable version is 0.17.3. Referencing #166 I have made changes to the ```Gemfile``` which will solve the issue. :smile: 