### PR TITLE
Upgraded GitHub Primer version

### DIFF
--- a/_includes/masthead.html
+++ b/_includes/masthead.html
@@ -14,7 +14,7 @@
   <div class="f4 mb-6">
     {% if user.name %}
       <div class="{{ metadata_styles }}">
-        {% octicon mark-github height:20 class:"mr-2 v-align-middle" fill:{{ icon_color }} aria-label:GitHub %}
+        {% octicon mark-github height:20 class:"mr-2 v-align-middle" color:{{ icon_color }} aria-label:GitHub %}
         <a href="https://github.com/{{ user.login }}" {% if site.style == 'dark' %}class="text-white"{% endif %}>
           @{{ user.login }}
         </a>
@@ -22,7 +22,7 @@
     {% endif %}
     {% if user.email %}
       <div class="{{ metadata_styles }}">
-        {% octicon mail height:20 class:"mr-2 v-align-middle" fill:{{ icon_color }} aria-label:email %}
+        {% octicon mail height:20 class:"mr-2 v-align-middle" color:{{ icon_color }} aria-label:email %}
         <a href="mailto:{{ user.email }}" {% if site.style == 'dark' %}class="text-white"{% endif %}>
           {{ user.email }}
         </a>
@@ -30,7 +30,7 @@
     {% endif %}
     {% if user.location %}
       <div class="{{ metadata_styles }} {% if site.style == 'dark' %}text-white{% endif %}">
-        {% octicon location height:20 class:"mr-2 v-align-middle" fill:{{ icon_color }} aria-label:Location %}
+        {% octicon location height:20 class:"mr-2 v-align-middle" color:{{ icon_color }} aria-label:Location %}
         {{ user.location }}
       </div>
     {% endif %}

--- a/assets/styles.scss
+++ b/assets/styles.scss
@@ -1,6 +1,6 @@
 ---
 ---
-@import url('https://unpkg.com/primer/build/build.css');
+@import url('https://cdnjs.cloudflare.com/ajax/libs/Primer/14.3.0/primer.min.css');
 @import 'highlight-syntax';
 
 


### PR DESCRIPTION
Currently, GitHub Personal Web site is using Primer 11.0, which is an outdated version and included some bugs, including with the visibility classes.

Also, Unpkg doesn't bundle newer versions of Primer.

This PR changes the CDN to CDNjs that is a faster CDN and supports the latest version of Primer.