### PR TITLE
Added Octicon for the Repo Card and added Repository Watchers

### DIFF
--- a/_includes/repo-card.html
+++ b/_includes/repo-card.html
@@ -20,7 +20,7 @@
         {% octicon star width:14 height:16 class:"mr-1" aria-label:star %}{{ repository.stargazers_count }}
       </a>
     {% endif %}
-    {% if repository.forks_count %}
+    {% if repository.watchers_count %}
       <a href="{{ repository.html_url }}/watchers" class="d-inline-block link-gray mr-4">
           {% octicon eye width:14 height:16 class:"mr-1" aria-label:forks %}{{ repository.watchers_count }}
       </a>

--- a/_includes/repo-card.html
+++ b/_includes/repo-card.html
@@ -17,12 +17,17 @@
     {% endif %}
     {% if repository.stargazers_count %}
       <a href="{{ repository.html_url }}/stargazers" class="d-inline-block link-gray mr-4">
-        <svg class="octicon octicon-star mr-1" viewBox="0 0 14 16" version="1.1" width="14" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M14 6l-4.9-.64L7 1 4.9 5.36 0 6l3.6 3.26L2.67 14 7 11.67 11.33 14l-.93-4.74L14 6z"></path></svg>{{ repository.stargazers_count }}
+        {% octicon star width:14 height:16 class:"mr-1" aria-label:star %}{{ repository.stargazers_count }}
+      </a>
+    {% endif %}
+    {% if repository.forks_count %}
+      <a href="{{ repository.html_url }}/watchers" class="d-inline-block link-gray mr-4">
+          {% octicon eye width:14 height:16 class:"mr-1" aria-label:forks %}{{ repository.watchers_count }}
       </a>
     {% endif %}
     {% if repository.forks_count %}
       <a href="{{ repository.html_url }}/network/members" class="d-inline-block link-gray mr-4">
-        <svg class="octicon octicon-git-branch mr-1" viewBox="0 0 10 16" version="1.1" width="10" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M10 5c0-1.11-.89-2-2-2a1.993 1.993 0 0 0-1 3.72v.3c-.02.52-.23.98-.63 1.38-.4.4-.86.61-1.38.63-.83.02-1.48.16-2 .45V4.72a1.993 1.993 0 0 0-1-3.72C.88 1 0 1.89 0 3a2 2 0 0 0 1 1.72v6.56c-.59.35-1 .99-1 1.72 0 1.11.89 2 2 2 1.11 0 2-.89 2-2 0-.53-.2-1-.53-1.36.09-.06.48-.41.59-.47.25-.11.56-.17.94-.17 1.05-.05 1.95-.45 2.75-1.25S8.95 7.77 9 6.73h-.02C9.59 6.37 10 5.73 10 5zM2 1.8c.66 0 1.2.55 1.2 1.2 0 .65-.55 1.2-1.2 1.2C1.35 4.2.8 3.65.8 3c0-.65.55-1.2 1.2-1.2zm0 12.41c-.66 0-1.2-.55-1.2-1.2 0-.65.55-1.2 1.2-1.2.65 0 1.2.55 1.2 1.2 0 .65-.55 1.2-1.2 1.2zm6-8c-.66 0-1.2-.55-1.2-1.2 0-.65.55-1.2 1.2-1.2.65 0 1.2.55 1.2 1.2 0 .65-.55 1.2-1.2 1.2z"></path></svg>{{ repository.forks_count }}
+        {% octicon git-branch width:10 height:16 class:"mr-1" aria-label:forks %}{{ repository.forks_count }}
       </a>
     {% endif %}
   </div>


### PR DESCRIPTION
This PR introduces slight changes to the `repo-card`.

* Replacing the plain SVG's (Stargazers and Forks) to the Octicons Jekyll macro.
* Introduced Repository watchers.