### PR TITLE
Added User Company to the Sidebar Profile

### DIFF
--- a/_includes/masthead.html
+++ b/_includes/masthead.html
@@ -20,6 +20,19 @@
         </a>
       </div>
     {% endif %}
+    {% if user.company %}
+      <div class="{{ metadata_styles }} {% if site.style == 'dark' %}text-white{% endif %}">
+        {% octicon organization height:20 class:"mr-2 v-align-middle" fill:{{ icon_color }} aria-label:Company %}
+        {% assign company = user.company | split: " " %}
+        {% for part in company %}
+          {% if part contains "@" %}
+            <a {% if site.style == 'dark' %}class="text-white"{% endif %} href="https://github.com/{{ part | replace: '@', '' }}">{{ part | replace: '@', '' | append: '&nbsp;' }}</a>
+          {% else %}
+            {{ part | append: '&nbsp;' }}
+          {% endif %}
+        {% endfor %}
+      </div>
+    {% endif %}
     {% if user.email %}
       <div class="{{ metadata_styles }}">
         {% octicon mail height:20 class:"mr-2 v-align-middle" fill:{{ icon_color }} aria-label:email %}


### PR DESCRIPTION
This Pull Request introduces the "User Company" field as of their GitHub.com profile.

It also checks if there are mentions to organizations by checking the presence of the `@` character. If there's one, it transforms into an URL to GitHub.com

This was the way I found to actually introduce the `<a href>`. I would love to hear if there's a more appropriate way... Since this one sounds too overengineered for it.