### PR TITLE
Allows to Jekyll recover GitHub Credentials from .netrc

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,3 +3,4 @@ gem 'github-pages', group: :jekyll_plugins
 gem "jekyll-github-metadata"
 gem "jekyll-octicons"
 gem "jemoji"
+gem "netrc"


### PR DESCRIPTION
Introduces a small change that allows Jekyll (`github-metadata`) to automatically recognize credentials that come from the `~/.netrc` file.

This change is recommended by `github-metadata` guidelines as you may check [here](https://github.com/jekyll/github-metadata/blob/master/docs/authentication.md).